### PR TITLE
IMPROVEMENT Add existing query params to pagination links

### DIFF
--- a/src/Laravel/Response.php
+++ b/src/Laravel/Response.php
@@ -41,6 +41,9 @@ class Response extends AbstractResponse
      */
     public function withPaginator(LengthAwarePaginator $paginator, $transformer, $resourceKey = null, $meta = [])
     {
+        $queryParams = array_diff_key($_GET, array_flip(['page']));
+        $paginator->appends($queryParams);
+        
         $resource = new Collection($paginator->items(), $transformer, $resourceKey);
         $resource->setPaginator(new IlluminatePaginatorAdapter($paginator));
 

--- a/tests/Laravel/ResponseTest.php
+++ b/tests/Laravel/ResponseTest.php
@@ -35,6 +35,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $paginator->shouldReceive('perPage')->andReturn(1);
         $paginator->shouldReceive('url')->andReturn('localhost');
         $paginator->shouldReceive('count')->andReturn(3);
+        $paginator->shouldReceive('appends')->andReturn([['foo' => 'bar']]);
 
         $response = new ResponseFake(new Manager());
 


### PR DESCRIPTION
This PR is to allow existing query params to be included within the pagination links.

At present a call to `/api/v1/search/?query=test` will return `/api/v1/search/?page=2` as the next link of the pagination links.

This update will now set the next link to be `/api/v1/search/?query=test&page=2` using the method outlined in the [Fractal](http://fractal.thephpleague.com/pagination/#including-existing-query-string-values-in-pagination-links) documentation.