### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,9 +209,9 @@ class BookController extends Controller {
 
 ```
 
-##Ouput example
+## Ouput example
 
-###One book
+### One book
 ```json
 {
     "data": {
@@ -232,7 +232,7 @@ class BookController extends Controller {
 }
 ```
 
-###Collection of books
+### Collection of books
 ```json
 {
     "data": [
@@ -270,7 +270,7 @@ class BookController extends Controller {
 }
 ```
 
-###Error
+### Error
 ```json
 {
     "error": {


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
