### PR TITLE
[FEATURE] optional resource key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - travis_retry composer install --no-interaction --prefer-source
 
 script:
-  - if [[ "$COLLECT_COVERAGE" == "true" ]]; then vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover; else vendor/bin/phpunit --no-coverage; fi
+  - if [[ "$COLLECT_COVERAGE" == "true" ]]; then composer test --coverage-text --coverage-clover=coverage.clover; else composer test --no-coverage; fi
 
 after_script:
   - if [[ "$COLLECT_COVERAGE" == "true" ]]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - travis_retry composer install --no-interaction --prefer-source
 
 script:
-  - if [[ "$COLLECT_COVERAGE" == "true" ]]; then composer test --coverage-text --coverage-clover=coverage.clover; else composer test --no-coverage; fi
+  - if [[ "$COLLECT_COVERAGE" == "true" ]]; then composer test -- --coverage-text --coverage-clover=coverage.clover; else composer test -- --no-coverage; fi
 
 after_script:
   - if [[ "$COLLECT_COVERAGE" == "true" ]]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### Status
+# api-response
 
 [![Latest Version](https://img.shields.io/github/release/ellipsesynergie/api-response.svg?style=flat-square)](https://github.com/ellipsesynergie/api-response/releases)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE)
@@ -8,8 +8,8 @@
 [![Total Downloads](https://img.shields.io/packagist/dt/ellipsesynergie/api-response.svg?style=flat-square)](https://packagist.org/packages/ellipsesynergie/api-response)
 [![SensioLabsInsight](https://insight.sensiolabs.com/projects/4d91348d-221b-4ee8-97cc-3e26383092c5/mini.png)](https://insight.sensiolabs.com/projects/4d91348d-221b-4ee8-97cc-3e26383092c5)
 
-Simple package to handle response properly in your API. This package use [Fractal](https://github.com/thephpleague/fractal)
-and are based on [Build APIs You Won't Hate](https://leanpub.com/build-apis-you-wont-hate) book.
+Simple package to handle response properly in your API. This package uses [Fractal](https://github.com/thephpleague/fractal)
+and is based on [Build APIs You Won't Hate](https://leanpub.com/build-apis-you-wont-hate) book.
 
 ## Install
 
@@ -29,30 +29,31 @@ The following versions of PHP are supported by this version.
 * PHP 7.0
 * PHP 7.1
 
-#### Install in Laravel 4
+### Install in Laravel 4
+
 Unfortunately, since the release 0.9.0, Laravel 4 is no longer supported because `league/fractal@0.12` no longer support this version. 
 However, you can use the version `0.8.*` if you need to use it inside Laravel 4.
 
-#### Install in Laravel 5
+### Install in Laravel 5
 Add this following service provider to your `config/app.php` file.
 
 ```php
 EllipseSynergie\ApiResponse\Laravel\ResponseServiceProvider
 ```
 
-#### Install in Lumen 5
+### Install in Lumen 5
+
 Register this service provider to your `bootstrap/app.php` file.
 
 ```php
 $app->register('EllipseSynergie\ApiResponse\Laravel\LumenServiceProvider');
 ```
 
-#### Install in Lumen 5.4+
+### Install in Lumen 5.4+
 
-Because of the request object change ([see reference](https://laravel-news.com/request-object-changes-in-lumen-5-4)) you can't no longuer access Request object properly in Service provider. To be convenient, we have created a middleware to be use for parsing include parameter.
+Because of the request object change ([see reference](https://laravel-news.com/request-object-changes-in-lumen-5-4)) you can no longer access `Request` object properly in Service provider. To be convenient, we have created a middleware to be used for parsing the `include` parameter.
 
 Register this service provider to your `bootstrap/app.php` file.
-
 
 ```php
 $app->register('EllipseSynergie\ApiResponse\Laravel\LumenServiceProvider');
@@ -66,15 +67,16 @@ $app->middleware([
 ]);
 ```
 
-#### Install in your favorite framework or vanilla php
-This package can be used in ANY framework or vanilla php. You simply need to extend `EllipseSynergie\ApiResponse\AbstractResponse` and implement the `withArray()` method in your custom class.
-You can take a look at `EllipseSynergie\ApiResponse\Laravel\Response::withArray()` for a example.
+### Install in your favorite framework or vanilla php
 
-If you have created a new implementation for a specific framework, i strongly recommend you to send a pull request to this repository.
+This package can be used in _any_ framework or vanilla php. You simply need to extend `EllipseSynergie\ApiResponse\AbstractResponse` and implement the `withArray()` method in your custom class.
+You can take a look at `EllipseSynergie\ApiResponse\Laravel\Response::withArray()` for an example.
+
+If you have created a new implementation for a specific framework, I strongly recommend you to send a pull request to this repository.
 
 You will also need to instantiate the response class with a fractal manager instance.
-```php
 
+```php
 // Instantiate the fractal manager
 $manager = new \League\Fractal\Manager;
 
@@ -85,11 +87,11 @@ $manager->parseIncludes(explode(',', $_GET['include']));
 $response = new \EllipseSynergie\ApiResponse\AbstractResponse($manager);
 ```
 
-For more option related to fractal manager, you can take a look at the [official website](http://fractal.thephpleague.com)
+For more options related to the fractal manager, you can take a look at the [official Fractal website](http://fractal.thephpleague.com)
 
 ## Example inside Laravel or Lumen controller
 
-``` php
+```php
 <?php
 
 use EllipseSynergie\ApiResponse\Contracts\Response;
@@ -97,7 +99,7 @@ use EllipseSynergie\ApiResponse\Contracts\Response;
 class BookController extends Controller {
 
     /**
-     * @param Response
+     * @param Response $response
      */
     public function __construct(Response $response)
     {
@@ -225,12 +227,12 @@ class BookController extends Controller {
         return $this->response->errorMethodNotAllowed("Please don't try this again !");
     }
 }
-
 ```
 
 ## Ouput example
 
 ### One book
+
 ```json
 {
     "data": {
@@ -252,6 +254,7 @@ class BookController extends Controller {
 ```
 
 ### Collection of books
+
 ```json
 {
     "data": [
@@ -308,7 +311,8 @@ $ phpunit
 ```
 
 ## Testing within Laravel
-According to the issue #31, we have found some problem when it's time to test the include query parameter value.
+
+According to the issue #31, we have found some problem when it's time to test the `include` query parameter value.
 If you want to resolve this issue in your test, you must use the trait `EllipseSynergie\ApiResponse\Testing\Laravel\AddTestingSupportForInclude`. To replace the `call` method from `Illuminate\Foundation\Testing\Concerns\MakesHttpRequests::call`
 
 ## Contributing

--- a/composer.json
+++ b/composer.json
@@ -40,5 +40,8 @@
         "branch-alias": {
           "dev-master": "0.16-dev"
         }
+    },
+    "scripts": {
+        "test": "@php vendor/bin/phpunit --colors=always"
     }
 }

--- a/src/Contracts/Response.php
+++ b/src/Contracts/Response.php
@@ -42,7 +42,7 @@ interface Response
      * @param array $array
      * @param array $headers
      * @param int $json_options @link http://php.net/manual/en/function.json-encode.php
-     * @return
+     * @return mixed
      */
     public function withArray(array $array, array $headers = [], $json_options = 0);
 

--- a/src/Laravel/Middleware/ParseInclude.php
+++ b/src/Laravel/Middleware/ParseInclude.php
@@ -10,7 +10,7 @@ use Illuminate\Http\Request;
  * Class ParseInclude
  * @package EllipseSynergie\ApiResponse\Laravel\Middleware
  */
-class ParseInclude 
+class ParseInclude
 {
     /**
      * @var Response
@@ -30,7 +30,7 @@ class ParseInclude
      * Handle middleware
      *
      * @param Request $request
-     * @param callable $next
+     * @param Closure $next
      * @return mixed
      */
     public function handle(Request $request, Closure $next)

--- a/src/Laravel/ResponseServiceProvider.php
+++ b/src/Laravel/ResponseServiceProvider.php
@@ -29,16 +29,26 @@ class ResponseServiceProvider extends ServiceProvider
     }
 
     /**
+     * Override this to use your own serializer.
+     *
+     * @return Serializer
+     */
+    protected function getSerializer()
+    {
+        return new Serializer();
+    }
+
+    /**
      * Boot response
      *
      * @return Response
      */
-    private function bootResponse()
+    protected function bootResponse()
     {
         $manager = new Manager;
 
         // Custom serializer because DataArraySerializer doesn't provide the opportunity to change the resource key
-        $manager->setSerializer(new Serializer());
+        $manager->setSerializer($this->getSerializer());
 
         // Are we going to try and include embedded data?
         $manager->parseIncludes(explode(',', $this->app['Illuminate\Http\Request']->get('include')));

--- a/src/Serializer/Serializer.php
+++ b/src/Serializer/Serializer.php
@@ -23,7 +23,8 @@ class Serializer extends ArraySerializer
      */
     public function collection($resourceKey, array $data)
     {
-        return [$resourceKey ? $resourceKey: static::RESOURCE_KEY => $data];
+        if (is_null($resourceKey)) $resourceKey = static::RESOURCE_KEY;
+        return $resourceKey ? [$resourceKey => $data]: $data;
     }
 
     /**
@@ -36,6 +37,7 @@ class Serializer extends ArraySerializer
      */
     public function item($resourceKey, array $data)
     {
-        return [$resourceKey ? $resourceKey: static::RESOURCE_KEY => $data];
+        if (is_null($resourceKey)) $resourceKey = static::RESOURCE_KEY;
+        return $resourceKey ? [$resourceKey => $data]: $data;
     }
 }

--- a/tests/Laravel/ResponseFactoryFake.php
+++ b/tests/Laravel/ResponseFactoryFake.php
@@ -161,4 +161,18 @@ class ResponseFactoryFake implements \Illuminate\Contracts\Routing\ResponseFacto
     {
         // TODO: Implement redirectToIntended() method.
     }
+
+    /**
+     * Return a new streamed response as a file download from the application.
+     *
+     * @param  \Closure $callback
+     * @param  string|null $name
+     * @param  array $headers
+     * @param  string|null $disposition
+     * @return \Symfony\Component\HttpFoundation\StreamedResponse
+     */
+    public function streamDownload($callback, $name = null, array $headers = [], $disposition = 'attachment')
+    {
+        // TODO: Implement streamDownload() method.
+    }
 }

--- a/tests/Laravel/ResponseTest.php
+++ b/tests/Laravel/ResponseTest.php
@@ -8,7 +8,7 @@ use Mockery as m;
 /**
  * Class ResponseTest
  *
- * @package EllipseSynergie\ApiResponse\Tests
+ * @package EllipseSynergie\ApiResponse\Tests\Laravel
  * @author Maxime Beaudoin <maxime.beaudoin@ellipse-synergie.com>
  */
 class ResponseTest extends \PHPUnit_Framework_TestCase

--- a/tests/Serializer/OptionalKeySerializer.php
+++ b/tests/Serializer/OptionalKeySerializer.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace EllipseSynergie\ApiResponse\Tests\Serializer;
+
+use EllipseSynergie\ApiResponse\Serializer\Serializer;
+
+/**
+ * Class OptionalKeySerializer
+ * @package EllipseSynergie\ApiResponse\Tests\Serializer
+ */
+class OptionalKeySerializer extends Serializer
+{
+    const RESOURCE_KEY = null;
+}

--- a/tests/Serializer/SerializerTest.php
+++ b/tests/Serializer/SerializerTest.php
@@ -14,41 +14,63 @@ class SerializerTest extends PHPUnit_Framework_TestCase
 {
     public function testCollectionWithDefaultResourceKey()
     {
+        $data = ['foo'];
         $serializer = new Serializer();
-        $result = $serializer->collection(null, ['foo']);
+        $result = $serializer->collection(null, $data);
 
-        $this->assertSame([
-            'data' => ['foo']
-        ], $result);
+        $this->assertSame(['data' => $data], $result);
     }
 
     public function testCollectionWithCustomResourceKey()
     {
+        $data = ['foo'];
         $serializer = new Serializer();
-        $result = $serializer->collection('custom', ['foo']);
+        $result = $serializer->collection('custom', $data);
 
-        $this->assertSame([
-            'custom' => ['foo']
-        ], $result);
+        $this->assertSame(['custom' => $data], $result);
+    }
+
+    public function testCollectionWithOptionalResourceKey()
+    {
+        $data = ['foo'];
+        $serializer = new OptionalKeySerializer();
+        $result = $serializer->collection(null, $data);
+
+        $this->assertSame($data, $result);
+
+        $result = $serializer->collection('optional', $data);
+
+        $this->assertSame(['optional' => $data], $result);
     }
 
     public function testItemWithDefaultResourceKey()
     {
+        $data = ['foo'];
         $serializer = new Serializer();
-        $result = $serializer->item(null, ['foo']);
+        $result = $serializer->item(null, $data);
 
-        $this->assertSame([
-            'data' => ['foo']
-        ], $result);
+        $this->assertSame(['data' => $data], $result);
     }
 
-    public function testITemWithCustomResourceKey()
+    public function testItemWithCustomResourceKey()
     {
+        $data = ['foo'];
         $serializer = new Serializer();
-        $result = $serializer->collection('custom', ['foo']);
+        $result = $serializer->collection('custom', $data);
 
-        $this->assertSame([
-            'custom' => ['foo']
-        ], $result);
+        $this->assertSame(['custom' => $data], $result);
+    }
+
+    public function testItemWithOptionalResourceKey()
+    {
+        $data = ['foo'];
+        $serializer = new OptionalKeySerializer();
+        $result = $serializer->item(null, $data);
+
+        $this->assertSame($data, $result);
+
+        $result = $serializer->item('optional', $data);
+
+        $this->assertSame(['optional' => $data], $result);
     }
 }


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide]().
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [x] I have used the project extensively, but have not contributed previously.
- [ ] I am an active contributor to the project.

**If the project maintainer has any additional requirements, they will be listed here.**

- No additional requirements.

---

Makes it easier to override the `\EllipseSynergie\ApiResponse\Laravel\ResponseServiceProvider` class to change the default serializer.

```php
class OptionalResourceKeyResponseServiceProvider extends ResponseServiceProvider
{
    protected function getSerializer()
    {
        return new OptionalKeySerializer();
    }
}
```

I also changed the default `\EllipseSynergie\ApiResponse\Serializer\Serializer` so that when `RESOURCE_KEY` constant is `null`, it returns the non-nested data as-is.

This helps remove nested `data` resource keys for each included resource.

If you still want to keep the root `data` property to wrap your resource, just specify this within your transformer. (Reference: https://github.com/thephpleague/fractal/issues/299)

```php
public function transform(Foo $foo)
{
    return [
        'data' => [
            'id' => (int) $foo->id,
            // ...etc.
        ]
    ];
}
```

Or when dealing with includes, specify a resource key when using the response:

```php
return $this->response->withCollection(
    $collection,
    $this->transformer,
    'data'
);
```

All tests are passing as it doesn't change the default behaviour so it's still backward compatible.
