### PR TITLE
[FIX]Removed Implicit marking parameter as nullable

### DIFF
--- a/src/AbstractResponse.php
+++ b/src/AbstractResponse.php
@@ -123,7 +123,7 @@ abstract class AbstractResponse implements Response
      * @param mixed $data
      * @param callable|\League\Fractal\TransformerAbstract $transformer
      * @param string $resourceKey
-     * @param Cursor $cursor
+     * @param ?Cursor $cursor
      * @param array $meta
      * @param array $headers
      * @return mixed
@@ -132,7 +132,7 @@ abstract class AbstractResponse implements Response
         $data,
         $transformer,
         $resourceKey = null,
-        Cursor $cursor = null,
+        ?Cursor $cursor = null,
         $meta = [],
         array $headers = []
     ) {

--- a/src/Contracts/Response.php
+++ b/src/Contracts/Response.php
@@ -59,7 +59,7 @@ interface Response
      * @param array $headers
      * @return mixed
      */
-    public function withItem($data, $transformer, string $resourceKey = null, array $meta = [], array $headers = []);
+    public function withItem($data, $transformer, ?string $resourceKey = null, array $meta = [], array $headers = []);
 
     /**
      * Response for collection of items
@@ -75,8 +75,8 @@ interface Response
     public function withCollection(
         $data,
         $transformer,
-        string $resourceKey = null,
-        Cursor $cursor = null,
+        ?string $resourceKey = null,
+        ?Cursor $cursor = null,
         array $meta = [],
         array $headers = []
     );


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide]().
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [x] I have used the project extensively, but have not contributed previously.
- [ ] I am an active contributor to the project.

---

We've been using this package for a long while, and when upgrading to PHP 8.4, we noticed output like this when running tests:

```
PHP Deprecated:  EllipseSynergie\ApiResponse\AbstractResponse::withCollection(): Implicitly marking parameter $cursor as nullable is deprecated, the explicit nullable type must be used instead in [PROJECT_FOLDER]/vendor/ellipsesynergie/api-response/src/AbstractResponse.php on line 131
PHP Deprecated:  EllipseSynergie\ApiResponse\Contracts\Response::withItem(): Implicitly marking parameter $resourceKey as nullable is deprecated, the explicit nullable type must be used instead in [PROJECT_FOLDER]/vendor/ellipsesynergie/api-response/src/Contracts/Response.php on line 62
```

This PR should fix that. Marking paramaters as nullable is supported in PHP 8.1.